### PR TITLE
Fix name of home RSS feed

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -50,9 +50,9 @@
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
-    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <description>Recent content {{ if not .IsHome }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo</generator>
     <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
     <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}


### PR DESCRIPTION
The home RSS feed currently renders as `Jonathan's Page on jneidel` because the home page's content title (`Jonathan's Page` from `content/_index.md`) does not equal `.Site.Title` (`jneidel`), so the template falls through to the `<Title> on <Site.Title>` branch.

Switch the special case in `layouts/_default/rss.xml` from `eq .Title .Site.Title` to `.IsHome`, matching the title logic already used in `layouts/partials/head.html`. The home feed becomes just `jneidel`; section feeds are unchanged (e.g. `/essay/rss.xml` stays `Essays on jneidel`).

### Before / after

| Endpoint                   | Before                                                | After                       |
| -------------------------- | ----------------------------------------------------- | --------------------------- |
| `/rss.xml` `<title>`       | `Jonathan's Page on jneidel`                          | `jneidel`                   |
| `/rss.xml` `<description>` | `Recent content in Jonathan's Page on jneidel`        | `Recent content on jneidel` |
| `/essay/rss.xml`           | `Essays on jneidel`                                   | `Essays on jneidel`         |

Verified locally with `hugo server` against both `en` (jneidel.com) and `de` (jneidel.de) outputs.

Closes #3