### PR TITLE
Set hreflang="x-default" on default language alternate

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -140,8 +140,14 @@
   {{/* hreflang: declare translations */}}
   {{- if .IsTranslated -}}
     <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+    {{- if .Language.IsDefault -}}
+      <link rel="alternate" hreflang="x-default" href="{{ .Permalink }}" />
+    {{- end -}}
     {{- range .Translations -}}
       <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+      {{- if .Language.IsDefault -}}
+        <link rel="alternate" hreflang="x-default" href="{{ .Permalink }}" />
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 


### PR DESCRIPTION
Per [Google's hreflang documentation](https://developers.google.com/search/docs/specialized/international/localized-versions#xdefault), the default-language URL of a translated page should additionally carry `hreflang="x-default"` so search engines have an unambiguous fallback for unmatched locales. Currently the site only emits `hreflang="en"` and `hreflang="de"`.

This adds an extra `<link rel="alternate" hreflang="x-default" ...>` next to the alternate whose `.Language.IsDefault` is true (`.Language.IsDefault` is available since Hugo 0.153; this repo pins 0.159.2 in `.hugo-version`). Pages without translations are unaffected -- the surrounding `.IsTranslated` guard is preserved.

### Before / after (head of `https://jneidel.com/`)

Before:
```html
<link rel="alternate" hreflang="en" href="https://jneidel.com/" />
<link rel="alternate" hreflang="de" href="https://jneidel.de/" />
```

After:
```html
<link rel="alternate" hreflang="en" href="https://jneidel.com/" />
<link rel="alternate" hreflang="x-default" href="https://jneidel.com/" />
<link rel="alternate" hreflang="de" href="https://jneidel.de/" />
```

Same on the `de` site -- `x-default` always points at the en URL regardless of which page is being viewed.

Verified locally with `hugo server` against `/`, `/about/`, and `/now/` on both `en` (jneidel.com) and `de` (jneidel.de) outputs; pages without translations correctly emit no hreflang block.

The issue notes the same fix should also be sent upstream to Congo -- not in scope here, this PR fixes the override in the site's own `layouts/partials/head.html`.

Closes #8