### PR TITLE
Soften TOC hover background in dark mode (closes #6)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -220,6 +220,7 @@ html.dark #content summary:after {
 
 html.dark .toc a:hover {
     color: rgb(var(--color-neutral-100));
+    background-color: rgb(var(--color-primary-900));
 }
 
 #content details[open] summary:after {


### PR DESCRIPTION
On hover the prose plugin paints TOC links with a `primary-600` background (`rgb(252, 6, 6)`). On the dark `neutral-800` canvas this lands as a saturated, eye-straining block of pure red on every TOC item the cursor crosses — that is the reading the issue describes.

This change adds a single dark-mode override on `html.dark .toc a:hover` that swaps the background to `primary-900`. Same brand red, lowest-saturation step, so the hover affordance stays visible (text remains `neutral-100`, contrast ~11:1) without the visual punch.

- Light mode: untouched (the existing primary-600 hover remains, and works against the light bg)
- Selector matches the existing `html.dark .toc a:hover` color rule a few lines up — keeps custom.css symmetrical
- No tokens added; uses existing `--color-primary-900`

Tested in headless Chromium 147 with `:hover` simulated via inline CSS so the full-row state could be screenshotted.

Closes #6